### PR TITLE
Updated to swift crypto.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,19 +1,23 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
-    name: "TelesignKit",
-    platforms: [ .macOS(.v10_14)],
+    name: "telesign-kit",
+    platforms: [ .macOS(.v10_15)],
     products: [
         .library(name: "TelesignKit", targets: ["TelesignKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/open-crypto.git", from: "4.0.0-beta")
+        .package(url: "https://github.com/swift-server/async-http-client.git", .exact("1.1.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [
-        .target(name: "TelesignKit", dependencies: ["AsyncHTTPClient", "NIOFoundationCompat", "OpenCrypto"]),
-        .testTarget(name: "TelesignKitTests", dependencies: ["AsyncHTTPClient", "TelesignKit"])
+        .target(name: "TelesignKit", dependencies: [
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "Crypto", package: "swift-crypto")
+        ]),
+        .testTarget(name: "TelesignKitTests", dependencies: [
+            .target(name: "TelesignKit")
+        ])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TelesignKit
 
-![](https://img.shields.io/badge/Swift-5-lightgrey.svg?style=svg)
+![](https://img.shields.io/badge/Swift-5.2-lightgrey.svg?style=svg)
 ![](https://img.shields.io/badge/SwiftNio-2-lightgrey.svg?style=svg)
 
 

--- a/Sources/TelesignKit/TelesignRequest.swift
+++ b/Sources/TelesignKit/TelesignRequest.swift
@@ -11,7 +11,7 @@ import NIO
 import NIOFoundationCompat
 import NIOHTTP1
 import AsyncHTTPClient
-import OpenCrypto
+import Crypto
 
 public protocol TelesignRequest {
     func send<TM: TelesignModel>(method: HTTPMethod, path: String, body: String) -> EventLoopFuture<TM>

--- a/Tests/TelesignKitTests/TelesignRequestTests.swift
+++ b/Tests/TelesignKitTests/TelesignRequestTests.swift
@@ -7,8 +7,6 @@
 
 import XCTest
 @testable import TelesignKit
-@testable import OpenCrypto
-@testable import NIOHTTP1
 
 class TelesignRequestTests: XCTestCase {
     struct MockTelesignRequest: TelesignRequest {}


### PR DESCRIPTION
This PR updates the dependencies to use `swift-crypto` and bumps the required version to `macOS  10.15`